### PR TITLE
Added .nu and .se to list of TLDs that support CDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Support in domain registries and registrars
 |.cr|No |Yes    |Yes   |7 days TCP-only|No|No documentation found; FRED is used|
 |[.cz](https://www.nic.cz/page/383/faq/#faq45)|No |Yes    |Yes   |7 days TCP-only|No|[FRED is used](https://fred.nic.cz/documentation/html/Concepts/AKM.html)|
 |[.li](https://www.nic.li/security/cds/)|Yes|No|Yes|72 hours TCP-only|No|[guidelines](https://www.nic.li/export/shared/.content/files/SWITCH_CDS_Manual_en.pdf)|
-|[.nu](https://internetstiftelsen.se/domaner/domannamnsbranschen/teknik/automatiserad-dnssec/)|Yes|No|Yes|72 hours TCP-only|No|[Policy and Guidelines]()|
-|[.se](https://internetstiftelsen.se/domaner/domannamnsbranschen/teknik/automatiserad-dnssec/)|Yes|No|Yes|72 hours TCP-only|No|[Policy and Guidelines]()|
+|[.nu](https://internetstiftelsen.se/domaner/domannamnsbranschen/teknik/automatiserad-dnssec/)|Yes|No|Yes|72 hours TCP-only|No|[Policy and Guidelines](https://internetstiftelsen.se/domaner/domannamnsbranschen/teknik/policy-and-guidelines-for-automated-dnssec-provisioning/)|
+|[.se](https://internetstiftelsen.se/domaner/domannamnsbranschen/teknik/automatiserad-dnssec/)|Yes|No|Yes|72 hours TCP-only|No|[Policy and Guidelines](https://internetstiftelsen.se/domaner/domannamnsbranschen/teknik/policy-and-guidelines-for-automated-dnssec-provisioning/)|
 |[.sk](https://sk-nic.sk/wp-content/uploads/2019/12/DNSSEC_CDS_EN.pdf)|Yes|No|Yes|72 hours|No|No clear information about using TCP for bootstrapping|
 |[RIPE NCC](https://www.ripe.net/manage-ips-and-asns/db/support/configuring-reverse-dns#4--automated-update-of-dnssec-delegations)|Yes|No|Yes|No|No||
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Support in domain registries and registrars
 |.cr|No |Yes    |Yes   |7 days TCP-only|No|No documentation found; FRED is used|
 |[.cz](https://www.nic.cz/page/383/faq/#faq45)|No |Yes    |Yes   |7 days TCP-only|No|[FRED is used](https://fred.nic.cz/documentation/html/Concepts/AKM.html)|
 |[.li](https://www.nic.li/security/cds/)|Yes|No|Yes|72 hours TCP-only|No|[guidelines](https://www.nic.li/export/shared/.content/files/SWITCH_CDS_Manual_en.pdf)|
-|[.nu]|Yes|No|Yes|Yes|No|
-|[.se]|Yes|No|Yes|Yes|No|
+|[.nu]|Yes|No|Yes|72 hours TCP-only|No||
+|[.se]|Yes|No|Yes|72 hours TCP-only|No||
 |[.sk](https://sk-nic.sk/wp-content/uploads/2019/12/DNSSEC_CDS_EN.pdf)|Yes|No|Yes|72 hours|No|No clear information about using TCP for bootstrapping|
 |[RIPE NCC](https://www.ripe.net/manage-ips-and-asns/db/support/configuring-reverse-dns#4--automated-update-of-dnssec-delegations)|Yes|No|Yes|No|No||
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Support in domain registries and registrars
 |.cr|No |Yes    |Yes   |7 days TCP-only|No|No documentation found; FRED is used|
 |[.cz](https://www.nic.cz/page/383/faq/#faq45)|No |Yes    |Yes   |7 days TCP-only|No|[FRED is used](https://fred.nic.cz/documentation/html/Concepts/AKM.html)|
 |[.li](https://www.nic.li/security/cds/)|Yes|No|Yes|72 hours TCP-only|No|[guidelines](https://www.nic.li/export/shared/.content/files/SWITCH_CDS_Manual_en.pdf)|
+|[.nu]|Yes|No|Yes|Yes|No|
+|[.se]|Yes|No|Yes|Yes|No|
 |[.sk](https://sk-nic.sk/wp-content/uploads/2019/12/DNSSEC_CDS_EN.pdf)|Yes|No|Yes|72 hours|No|No clear information about using TCP for bootstrapping|
 |[RIPE NCC](https://www.ripe.net/manage-ips-and-asns/db/support/configuring-reverse-dns#4--automated-update-of-dnssec-delegations)|Yes|No|Yes|No|No||
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Support in domain registries and registrars
 |.cr|No |Yes    |Yes   |7 days TCP-only|No|No documentation found; FRED is used|
 |[.cz](https://www.nic.cz/page/383/faq/#faq45)|No |Yes    |Yes   |7 days TCP-only|No|[FRED is used](https://fred.nic.cz/documentation/html/Concepts/AKM.html)|
 |[.li](https://www.nic.li/security/cds/)|Yes|No|Yes|72 hours TCP-only|No|[guidelines](https://www.nic.li/export/shared/.content/files/SWITCH_CDS_Manual_en.pdf)|
-|[.nu]|Yes|No|Yes|72 hours TCP-only|No||
-|[.se]|Yes|No|Yes|72 hours TCP-only|No||
+|[.nu](https://internetstiftelsen.se/domaner/domannamnsbranschen/teknik/automatiserad-dnssec/)|Yes|No|Yes|72 hours TCP-only|No|[Policy and Guidelines]()|
+|[.se](https://internetstiftelsen.se/domaner/domannamnsbranschen/teknik/automatiserad-dnssec/)|Yes|No|Yes|72 hours TCP-only|No|[Policy and Guidelines]()|
 |[.sk](https://sk-nic.sk/wp-content/uploads/2019/12/DNSSEC_CDS_EN.pdf)|Yes|No|Yes|72 hours|No|No clear information about using TCP for bootstrapping|
 |[RIPE NCC](https://www.ripe.net/manage-ips-and-asns/db/support/configuring-reverse-dns#4--automated-update-of-dnssec-delegations)|Yes|No|Yes|No|No||
 


### PR DESCRIPTION
Since the beginning of October both .se and .nu actively scan for CDS records and update the registry accordingly.