### PR TITLE
.swiss/.whoswho backed down for now (private beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ Support in domain registries
 |[.se](https://internetstiftelsen.se/domaner/domannamnsbranschen/teknik/automatiserad-dnssec/)|Yes|No|Yes|72 hours TCP-only||Yes|[Policy and Guidelines](https://internetstiftelsen.se/domaner/domannamnsbranschen/teknik/policy-and-guidelines-for-automated-dnssec-provisioning/)|
 |[.sk](https://sk-nic.sk/wp-content/uploads/2019/12/DNSSEC_CDS_EN.pdf)|Yes|No|Yes|72 hours||No|No clear information about using TCP for bootstrapping|
 |.alt.za, .edu.za|Yes|No|Yes|72 hours|No|No||
-|.swiss|No|Yes|Yes|at registration time|Yes|No|[Documentation](https://cp.nic.swiss/doc-manuals) (Login required)|
-|.whoswho|No|Yes|Yes|at registration time|Yes|No|[Documentation](https://cp.nic.whoswho/doc-manuals) (Login required)|
 |[RIPE NCC](https://www.ripe.net/manage-ips-and-asns/db/support/configuring-reverse-dns#4--automated-update-of-dnssec-delegations)|Yes|No|Yes|No||No||
 
 Support in domain registrars


### PR DESCRIPTION
as explained at ICANN76