### PR TITLE
Update _dsboot support for Glauca

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Support in domain registrars
 
 |Registrar|CDS|CDNSKEY|Delete|Bootstrap from insecure|Bootstrap via `_dsboot`|CSYNC|Notes|
 |---------|---|-------|------|-----------------------|------------------------|--|-----|
-|[Glauca](https://glauca.digital/blog/2020/08/10/cds-at-the-registrar-level.html)|Yes|Yes|Yes|All name servers must respond the same, TCP-only|In progress|?|[Docs](https://docs.glauca.digital/domains/cds/)|
+|[Glauca](https://glauca.digital/blog/2020/08/10/cds-at-the-registrar-level.html)|Yes|Yes|Yes|All name servers must respond the same, TCP-only|Yes|?|[Docs](https://docs.glauca.digital/domains/cds/)|
 |[Domainnameshop](https://domainname.shop/faq?id=395&section=7)|Yes|Yes|Yes|All name servers must respond the same, TCP-only|Possible future|No||
 
 Support in DNS providers

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Support in domain registrars
 
 |Registrar|CDS|CDNSKEY|Delete|Bootstrap from insecure|Bootstrap via `_dsboot`|CSYNC|Notes|
 |---------|---|-------|------|-----------------------|------------------------|--|-----|
-|[Glauca](https://glauca.digital/blog/2020/08/10/cds-at-the-registrar-level.html)|Yes|?|?|?|?|?||
+|[Glauca](https://glauca.digital/blog/2020/08/10/cds-at-the-registrar-level.html)|Yes|Yes|Yes|All name servers must respond the same, TCP-only|In progress|?|[Docs](https://docs.glauca.digital/domains/cds/)|
 
 Support in DNS providers
 ------------------------
@@ -38,7 +38,7 @@ Support in DNS providers
 |[Cloudflare](https://blog.cloudflare.com/automatically-provision-and-maintain-dnssec/)|Yes|Yes|Yes|Yes||
 |[deSEC](https://desec.io/)|Yes|Yes|Yes|Yes|[docs](https://desec.readthedocs.io/en/latest/dns/rrsets.html#dnskey-caveat)|
 |[DNSimple](https://support.dnsimple.com/articles/dnssec/#cdscdnskey)|Yes|Yes|||[blog post](https://blog.dnsimple.com/2019/02/cds_cdnskey/)|
-|[Glauca HexDNS](https://docs.glauca.digital/domains/cds/)|Yes|Yes||in progress||
+|[Glauca HexDNS](https://docs.glauca.digital/domains/cds/)|Yes|Yes|Yes|Yes||
 |[GoDaddy](https://uk.godaddy.com/help/enable-dnssec-in-my-premium-dns-account-6420)|Yes|Yes|||[presentation at ICANN 68](https://68.schedule.icann.org/meetings/EqJCzT5N6kcZhh2TT)|
 
 Parent-side software


### PR DESCRIPTION
Glauca now supports authenticated bootstrapping with `_dsboot`.