### PR TITLE
Add dnssec-publish-ds to parent-side software

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ Parent-side software
  - multithreaded scanning
  - no support for bootstrapping from insecure
 
+### [dnssec-publish-ds](https://github.com/BugMaster510945/dnssec-publish-ds)
+ - written in Go as a long-running daemon
+ - consumes CDS and CDNSKEY records and continuously reconciles parent DS records
+ - supports DS publication through pluggable providers (currently RFC2136 Dynamic DNS UPDATE and OVH)
+ - relies on a DNSSEC-validating recursive resolver (AD bit required) for CDS/CDNSKEY/DS lookups
+   does not currently implement RFC 9615 (DNSSEC bootstrapping), RFC 9859 (DNSSEC removal), or the authoritative multi-NS consistency checks and CSYNC processing described in RFC 9975
+ 
 Child-side software
 -------------------
 


### PR DESCRIPTION
This PR adds `dnssec-publish-ds` to the Parent-side software section.

`dnssec-publish-ds` is a Go daemon that automates CDS/CDNSKEY-based DS synchronization by consuming child-published records and publishing DS updates through pluggable providers.

The entry documents:
- CDS/CDNSKEY consumption and DS reconciliation workflow
- supports DS publication through a pluggable provider architecture (currently RFC2136 Dynamic DNS UPDATE and OVH providers)
- DNSSEC-validating resolver requirement (AD bit required)
- current RFC coverage and limitations:
  - RFC 7344 / RFC 8078: implements the CDS/CDNSKEY-based DS synchronization workflow
  - RFC 9975: does not currently implement authoritative multi-NS consistency checks or CSYNC processing
  - RFC 9615: not implemented (DNSSEC bootstrapping)
  - RFC 9859: not implemented (DNSSEC removal)

The implementation currently relies on a DNSSEC-validating recursive resolver for CDS/CDNSKEY/DS lookups rather than performing authoritative multi-server validation itself.

The project is currently used by myself to manage DNSSEC updates for personal domains.